### PR TITLE
[FEATURE] Add logout and removeSession features

### DIFF
--- a/middleware/userGuard.js
+++ b/middleware/userGuard.js
@@ -7,19 +7,18 @@ router.use('/', async (req, res, next) => {
         return res.status(500).json({ error: decoded.error });
     }
 
-    const isAdmin = decoded.data.role === 'admin';
+    const isUser = decoded.data.role === 'user';
     const isActive = decoded.data.status === 'active';
 
-    if (!isAdmin) {
+    if (!isUser) {
         return res.status(401).send('Unauthorized');
     }
     if (!isActive) {
-        return res.status(401).send('Logged Out');
+        return res.status(200).send('Logged Out');
     }
-
-    req.body = { ...req.body, token: { email: decoded.data.email } };
+    
+    req.body = { ...req.body, token: decoded.data };
     next();
 })
-
 
 module.exports = router;

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -1,5 +1,7 @@
 const router = require('express').Router();
 const insertUser = require('../service/insertUser');
+const findEmail = require('../service/findEmail');
+const updateField = require('../service/updateField');
 const adminGuard = require('../middleware/adminGuard');
 const registerValidator = require('../validations/register');
 
@@ -9,18 +11,59 @@ router.post('/register', adminGuard, async (req, res) => {
 
     const { error } = registerValidator({ email, password, role, status });
 
-    if(error){
+    if (error) {
         return res.status(400).send(error.details[0].message);
+    }
+
+    const isExist = await findEmail(email);
+
+    if (!isExist) {
+        return res.status(400).json({ error: 'Admin account does not exist' });
     }
 
     const user = await insertUser({ email, password, role, status });
 
-    if(user){
+    if (user) {
         return res.status(201).send(user);
     }
 
     return res.status(500).send('Error registering user, maybe the email is already in use');
 })
 
+/*
+* Only Admin are allowed to remove their session using this server endpoint
+*/
+router.patch("/logout", adminGuard, async (req, res) => {
+    const isAdmin = req.body.token;
+    const isExist = await findEmail(isAdmin.email);
+
+    if (!isExist) {
+        return res.status(400).json({ error: 'Admin account does not exist' });
+    }
+    const updatedUser = await updateField({ email: isAdmin.email, status: 'inactive' });
+    return res.status(200).send("Logged Out");
+});
+
+router.post("/logout", adminGuard, async (req, res) => {
+    const isAdmin = req.body.token;
+    const isExist = await findEmail(isAdmin.email);
+
+    if (!isExist) {
+        return res.status(400).json({ error: 'Admin account does not exist' });
+    }
+
+    const isUserExist = await findEmail(req.body.email);
+
+    if (!isUserExist) {
+        return res.status(400).json({ error: 'User account does not exist' });
+
+    } else if (isUserExist.role !== 'user') {
+        return res.status(403).json({ error: 'Cannot remove Admin session' });
+
+    } else {
+        const updatedUser = await updateField({ email: isUserExist.email, status: 'inactive' });
+        return res.status(200).send("Logged Out");
+    }
+});
 
 module.exports = router;

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -55,10 +55,11 @@ router.post("/logout", adminGuard, async (req, res) => {
     const isUserExist = await findEmail(req.body.email);
 
     if (!isUserExist) {
-        return res.status(400).json({ error: 'User account does not exist' });
+        return res.status(404).json({ error: 'User account does not exist' });
 
-    } else if (isUserExist.role !== 'user') {
-        return res.status(403).json({ error: 'Cannot remove Admin session' });
+    } else if (isUserExist.role !== 'user' && isUserExist.email !== isAdmin.email) {
+        // return res.status(403).json({ error: 'Cannot remove another Admins\' session' });
+        return res.status(403).json({ error: 'Forbidden' });
 
     } else {
         const updatedUser = await updateField({ email: isUserExist.email, status: 'inactive' });

--- a/routes/user.js
+++ b/routes/user.js
@@ -2,6 +2,9 @@ const router = require("express").Router();
 const { options } = require("joi");
 const createToken = require("../service/createToken");
 const findUser = require("../service/findUser");
+const findEmail = require("../service/findEmail");
+const updateField = require("../service/updateField");
+const userGuard = require("../middleware/userGuard");
 const loginValidator = require("../validations/login");
 
 router.post("/login", async (req, res) => {
@@ -29,6 +32,20 @@ router.post("/login", async (req, res) => {
   }
 
   return res.status(400).json({ error: "Invalid email or password" });
+});
+
+/*
+* User is allowed to remove users' session using this server endpoint
+*/
+router.patch("/logout", userGuard, async (req, res) => {
+  const isUser = req.body.token;
+  const isExist = await findEmail(isUser.email);
+
+  if(!isExist){
+      return res.status(400).json({ error: 'User account does not exist' });
+  }
+  const updatedUser = await updateField({ email: isExist.email, status: 'inactive' });
+  return res.status(200).send("Logged Out");
 });
 
 module.exports = router;

--- a/service/createToken.js
+++ b/service/createToken.js
@@ -1,10 +1,11 @@
 const jwt = require('jsonwebtoken');
 const privateKey = process.env.JWT_RSA_PRIVATE_KEY;
+const passphrase = process.env.JWT_SECRET
 const expirationTime = process.env.JWT_EXPIRATION_TIME;
 
 module.exports = async function (payload) {
-    const token = jwt.sign(payload, privateKey, {
-        algorithm:'RS256', 
+    const token = jwt.sign(payload, {key: privateKey, passphrase}, {
+        algorithm:'RS256',
         expiresIn: expirationTime
     });
     return token;

--- a/service/decodeToken.js
+++ b/service/decodeToken.js
@@ -1,0 +1,11 @@
+const jwt = require('jsonwebtoken');
+
+module.exports = async function decodeToken(req) {
+    const publicKey = process.env.JWT_RSA_PUBLIC_KEY;
+    const token = req.header('Authorization').replace('Bearer ', '');
+    try {
+        return { status: true, data: jwt.verify(token, publicKey) };
+    } catch (error) {
+        return { status: false, error: error.message };
+    }
+}

--- a/service/findEmail.js
+++ b/service/findEmail.js
@@ -1,0 +1,9 @@
+const mongodb = require('../config/mongodb');
+
+module.exports = async function findEmail(email) {
+    const isExist = await mongodb()
+        .collection('users')
+        .findOne({ email });
+
+    return isExist || false;
+}

--- a/service/findUser.js
+++ b/service/findUser.js
@@ -1,13 +1,11 @@
 const bcrypt = require('bcrypt');
-const mongodb = require('../config/mongodb');
+const findEmail = require('./findEmail');
 
 module.exports = async function findUser({email, password}) {
-    const user = await mongodb()
-        .collection('users')
-        .findOne({email});
+    const user = await findEmail(email);
 
     if(user){
-        const isMatch = await bcrypt.compare(password, user.password);
+        const isMatch = await bcrypt.compare(password, user.hashedPassword);
         if(isMatch){
             return user;
         }

--- a/service/insertUser.js
+++ b/service/insertUser.js
@@ -1,18 +1,11 @@
-const mongodb = require('../config/mongodb');
 const bcrypt = require('bcrypt');
+const mongodb = require('../config/mongodb');
 
 module.exports = async function insertUser({email, password, role, status}) {
-    const isExist = await mongodb()
-        .collection('users')
-        .findOne({email});
-
-    if(isExist){
-        return null;
-    }
     const hashedPassword = await bcrypt.hash(password, 10);
     const user = await mongodb()
         .collection('users')
         .insertOne({email, hashedPassword, role, status});
-    
+
     return user;
 }

--- a/service/updateField.js
+++ b/service/updateField.js
@@ -1,0 +1,8 @@
+const mongodb = require('../config/mongodb');
+
+module.exports = async function updateField(option) {
+    let user = await mongodb()
+        .collection('users')
+        .updateOne({ [Object.keys(option)[0]]: option[Object.keys(option)[0]] }, { $set: { [Object.keys(option)[1]]: option[Object.keys(option)[1]] } });
+    return user;
+}


### PR DESCRIPTION
### Functions
1. #### `logout`
    - Users and admin can logout themselves, that is, changing `status` field value from `active` to `inactive`
    - Constraints -
      > - User should provide their own token within the `Authorization` header to logout their own session using `patch('/user/logout')`
      > - Admin should provide their own token within the `Authorization` header to logout their own session using `patch('/admin/logout')`

2. #### `removeSession`
    - Admin can change the `status` of user accounts and also itself but cannot alter in another admins account
    - Constraints -
      > - Admin should provide their own token within the `Authorization` header to authenticate admins' access and provide email of the user account or itself whose session needs to be removes in request body `{ "email": "user@test.com" }` to `post('/admin/logout')`
<hr />

> _Attaching the new API endpoints structure_
>
> ![image](https://user-images.githubusercontent.com/79781388/197606999-edc8bb64-7c46-4a55-bad2-8a179d23bb4e.png)

> Successfully merging this pull request may fixes #1